### PR TITLE
Remove new instance of EngineModule for each UI settings change

### DIFF
--- a/EngineLightRelit/DynamicSettings.cs
+++ b/EngineLightRelit/DynamicSettings.cs
@@ -35,8 +35,6 @@ namespace EngineLightRelit
         Rect win;
         bool visible = false;
 
-        internal static bool ConfigChanged = false;
-
         void Start()
         {
             win = new Rect(100, 100, 400, 175);
@@ -63,7 +61,6 @@ namespace EngineLightRelit
         void Toggle()
         {
             visible = !visible;
-            ConfigChanged = false;
         }
         int id = 457984233;
         void OnGUI()
@@ -89,7 +86,6 @@ namespace EngineLightRelit
             if (newValue != HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightFadeCoefficient)
             {
                 HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightFadeCoefficient = newValue;
-                ConfigChanged = true;
             }
             GUILayout.EndHorizontal();
 
@@ -101,7 +97,6 @@ namespace EngineLightRelit
             if (newValue != HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightPower)
             {
                 HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightPower = newValue;
-                ConfigChanged = true;
             }
             GUILayout.EndHorizontal();
 
@@ -113,7 +108,6 @@ namespace EngineLightRelit
             if (newValue != HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightRange)
             {
                 HighLogic.CurrentGame.Parameters.CustomParams<EL>().lightRange = newValue;
-                ConfigChanged = true;
             }
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();

--- a/EngineLightRelit/EngineLightEffect.cs
+++ b/EngineLightRelit/EngineLightEffect.cs
@@ -455,11 +455,6 @@ namespace EngineLightRelit
 #endif
 		        return; // I guess this might happen for a frame or two while a scene is still loading? should be harmless - we can wait
 	        }
-			if (  DynamicSettings.ConfigChanged)
-            {
-				initEngineLights();
-				DynamicSettings.ConfigChanged = false;
-			}
 			try
 			{
 				// these _really_ shouldn't be happening - if one does we need to fix it, not ignore it. 


### PR DESCRIPTION
I don't why there was basically this settings change check but today it isn't necessary anymore.
It make a new EngineModule each time you change values by UI toolbars and make UI toolbars unusable. So it need to remove it.