### PR TITLE
Fixed emissive, and added solid fuel booster config

### DIFF
--- a/EngineLightRelit/EngineLightEffect.cs
+++ b/EngineLightRelit/EngineLightEffect.cs
@@ -356,14 +356,16 @@ namespace EngineLightRelit
                         emissiveColorQuadModifier = new Color(emissiveQuadRed, emissiveQuadGreen, emissiveQuadBlue);
                 }
 
-                exhaustColor = new Color(exhaustRed, exhaustGreen, exhaustBlue);
+                if (exhaustColor.a == 0)
+                    exhaustColor = new Color(exhaustRed, exhaustGreen, exhaustBlue);
 
                 // increase the minimum light range for larger parts
                 AttachNode node = this.part.FindModuleImplementing<AttachNode>();
                 if (node != null)
                     minimumLightRange += node.radius;
 
-                jitterBuffer = new JitterBuffer();
+                if (jitterBuffer == null)
+                    jitterBuffer = new JitterBuffer();
 
                 // cache function call
                 float maxThrust = engineModule.getMaxThrust();
@@ -404,7 +406,8 @@ namespace EngineLightRelit
                 engineLightObject.transform.position = averageThrustTransform;
 
                 // this (like colour) is applied per-frame - because it looks better
-                lightOffset = new Vector3(lightOffsetX, 0, lightOffsetY);
+                if (lightOffsetX != lightOffset.x || lightOffsetY != lightOffset.z)
+                    lightOffset.Set(lightOffsetX, 0, lightOffsetY);
 
                 // and we're done - register our local variables and flag success
                 //this.engineLightObject = engineLightObject;

--- a/EngineLightRelit/EngineLightEffect.cs
+++ b/EngineLightRelit/EngineLightEffect.cs
@@ -349,15 +349,36 @@ namespace EngineLightRelit
                 else
                 {
                     if (emissiveColor.a == 0)
-                        emissiveColor = emissiveColorBase = new Color(emissiveRed, emissiveGreen, emissiveBlue);
+                    {
+                        emissiveColor.r = emissiveColorBase.r = emissiveRed;
+                        emissiveColor.g = emissiveColorBase.g = emissiveGreen;
+                        emissiveColor.b = emissiveColorBase.b = emissiveBlue;
+                        emissiveColor.a = emissiveColorBase.a = 1;
+                    }
                     if (emissiveColorLogModifier.a == 0)
-                        emissiveColorLogModifier = new Color(emissiveLogRed, emissiveLogGreen, emissiveLogBlue);
+                    {
+                        emissiveColorLogModifier.r = emissiveLogRed;
+                        emissiveColorLogModifier.g = emissiveLogGreen;
+                        emissiveColorLogModifier.b = emissiveLogBlue;
+                        emissiveColorLogModifier.a = 1;
+                    }
                     if (emissiveColorQuadModifier.a == 0)
-                        emissiveColorQuadModifier = new Color(emissiveQuadRed, emissiveQuadGreen, emissiveQuadBlue);
+                    {
+                        emissiveColorQuadModifier.r = emissiveQuadRed;
+                        emissiveColorQuadModifier.g = emissiveQuadGreen;
+                        emissiveColorQuadModifier.b = emissiveQuadBlue;
+                        emissiveColorQuadModifier.a = 1;
+                    }
                 }
+                Utils.log("Vandest verif - After: emissiveColor = " + emissiveColor.ToString());
 
                 if (exhaustColor.a == 0)
-                    exhaustColor = new Color(exhaustRed, exhaustGreen, exhaustBlue);
+                {
+                    exhaustColor.r = exhaustRed;
+                    exhaustColor.g = exhaustGreen;
+                    exhaustColor.b = exhaustBlue;
+                    exhaustColor.a = 1;
+                }
 
                 // increase the minimum light range for larger parts
                 AttachNode node = this.part.FindModuleImplementing<AttachNode>();

--- a/EngineLightRelit/EngineLightEffect.cs
+++ b/EngineLightRelit/EngineLightEffect.cs
@@ -348,11 +348,11 @@ namespace EngineLightRelit
                     enableEmissiveLight = false;
                 else
                 {
-                    if (emissiveColor == null)
+                    if (emissiveColor.a == 0)
                         emissiveColor = emissiveColorBase = new Color(emissiveRed, emissiveGreen, emissiveBlue);
-                    if (emissiveColorLogModifier == null)
+                    if (emissiveColorLogModifier.a == 0)
                         emissiveColorLogModifier = new Color(emissiveLogRed, emissiveLogGreen, emissiveLogBlue);
-                    if (emissiveColorQuadModifier == null)
+                    if (emissiveColorQuadModifier.a == 0)
                         emissiveColorQuadModifier = new Color(emissiveQuadRed, emissiveQuadGreen, emissiveQuadBlue);
                 }
 

--- a/GameData/EngineLightRelit/MM_Configs/engine-configs.cfg
+++ b/GameData/EngineLightRelit/MM_Configs/engine-configs.cfg
@@ -411,8 +411,8 @@
 	}
 }
 
-// shift solids to more yellow and increase the flickering effect
-@PART[solidBooster|solidBooster1-1|solidBooster_sm|MassiveBooster]:FOR[EngineLight]
+// shift solids to more yellow and increase the flickering effect (but a little less yellow than before)
+@PART[solidBooster_v2|solidBooster_sm_v2|Thoroughbred|Clydesdale]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
@@ -420,13 +420,15 @@
 		%lightRange = 11.0
 		%jitterMultiplier = 0.16
 		
-		%exhaustRed = 0.9
-		%exhaustGreen = 0.85
-		%exhaustBlue = 0.43
+		%exhaustRed = 0.95
+		%exhaustGreen = 0.86
+		%exhaustBlue = 0.58
 	}
 }
 
-@PART[solidBooster_sm]:FOR[EngineLight]
+
+// RT-5 "Flea"
+@PART[solidBooster_sm_v2]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
@@ -434,7 +436,8 @@
 	}
 }
 
-@PART[solidBooster]:FOR[EngineLight]
+// RT-10 "Hammer"
+@PART[solidBooster_v2]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
@@ -443,23 +446,86 @@
 	}
 }
 
+// BACC "Thumper"
 @PART[solidBooster1-1]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveOffsetZ = 5.4
+		%emissiveOffsetZ = 5.3
 		%exhaustOffsetZ = 6.8
 	}
 }
 
+// S1 SRB-KD25k "Kickback"
 @PART[MassiveBooster]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveOffsetZ = 10.0
+		%emissiveOffsetZ = 9.5
 		%exhaustOffsetZ = 12.0
 	}
 }
+
+// F3S0 "Shrimp"
+@PART[Shrimp]:FOR[EngineLight]
+{
+	@MODULE[EngineLightEffect]
+	{
+		%emissiveRed = 0.4
+		%emissiveLogGreen = 0.07
+		%emissiveQuadGreen = 0.3
+		%emissiveLogRed = 0.2
+		%emissiveOffsetZ = 2.8
+		%exhaustOffsetZ = 4.0
+	}
+}
+
+// FM1 "Mite"
+@PART[Mite]:FOR[EngineLight]
+{
+	@MODULE[EngineLightEffect]
+	{
+		%emissiveRed = 0.4
+		%emissiveLogGreen = 0.07
+		%emissiveQuadGreen = 0.3
+		%emissiveLogRed = 0.2
+		%emissiveOffsetZ = 1.5
+		%exhaustOffsetZ = 2.5
+	}
+}
+
+// S2-17 "Pur-sang"
+@PART[Thoroughbred]:FOR[EngineLight]
+{
+	@MODULE[EngineLightEffect]
+	{
+		%exhaustOffsetZ = 8.5
+		%emissiveOffsetZ = 7.5
+	}
+}
+
+// S2-33 "Clydesdale"
+@PART[Clydesdale]:FOR[EngineLight]
+{
+	@MODULE[EngineLightEffect]
+	{
+		%exhaustOffsetZ = 15.0
+		%emissiveOffsetZ = 12.5
+	}
+}
+
+// DLC ---------------------------
+// THK "Pollux"
+@PART[Pollux]:FOR[EngineLight]
+{
+	@MODULE[EngineLightEffect]
+	{
+		%exhaustOffsetZ = 9.8
+		%emissiveOffsetZ = 8
+	}
+}
+// -------------------------------
+
 
 // boost output light (a lot!) from the NERV
 @PART[nuclearEngine]:FOR[EngineLight]

--- a/GameData/EngineLightRelit/MM_Configs/engine-configs.cfg
+++ b/GameData/EngineLightRelit/MM_Configs/engine-configs.cfg
@@ -412,7 +412,7 @@
 }
 
 // shift solids to more yellow and increase the flickering effect (but a little less yellow than before)
-@PART[solidBooster_v2|solidBooster_sm_v2|Thoroughbred|Clydesdale]:FOR[EngineLight]
+@PART[solidBooster_v2|solidBooster_sm_v2|solidBooster1-1|MassiveBooster|Shrimp|Mite|Thoroughbred|Clydesdale|Pollux]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
@@ -420,7 +420,7 @@
 		%lightRange = 11.0
 		%jitterMultiplier = 0.16
 		
-		%exhaustRed = 0.95
+		%exhaustRed = 0.90
 		%exhaustGreen = 0.86
 		%exhaustBlue = 0.58
 	}
@@ -441,7 +441,6 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveOffsetZ = 2.8
 		%exhaustOffsetZ = 3.6
 	}
 }
@@ -451,8 +450,13 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveOffsetZ = 5.3
+		%emissiveRed = 0.22
+		%emissiveLogRed = 0.12
+		%emissiveLogGreen = 0.025
+		%emissiveQuadGreen = 0.25
+		%emissiveQuadBlue = 0.025
 		%exhaustOffsetZ = 6.8
+		%emissiveOffsetZ = 3.7
 	}
 }
 
@@ -461,8 +465,13 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveOffsetZ = 9.5
+		%emissiveRed = 0.28
+		%emissiveLogRed = 0.18
+		%emissiveLogGreen = 0.025
+		%emissiveQuadGreen = 0.25
+		%emissiveQuadBlue = 0.025
 		%exhaustOffsetZ = 12.0
+		%emissiveOffsetZ = 7.1
 	}
 }
 
@@ -471,11 +480,12 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveRed = 0.4
-		%emissiveLogGreen = 0.07
-		%emissiveQuadGreen = 0.3
+		%emissiveRed = 0.3
 		%emissiveLogRed = 0.2
-		%emissiveOffsetZ = 2.8
+		%emissiveLogGreen = 0.05
+		%emissiveQuadGreen = 0.25
+		%emissiveQuadBlue = 0.025
+		%emissiveOffsetZ = 1.7
 		%exhaustOffsetZ = 4.0
 	}
 }
@@ -485,22 +495,23 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%emissiveRed = 0.4
-		%emissiveLogGreen = 0.07
-		%emissiveQuadGreen = 0.3
+		%emissiveRed = 0.3
 		%emissiveLogRed = 0.2
-		%emissiveOffsetZ = 1.5
+		%emissiveLogGreen = 0.05
+		%emissiveQuadGreen = 0.25
+		%emissiveQuadBlue = 0.025
+		%emissiveOffsetZ = 0.7
 		%exhaustOffsetZ = 2.5
 	}
 }
 
-// S2-17 "Pur-sang"
+// S2-17 "Thoroughbred"
 @PART[Thoroughbred]:FOR[EngineLight]
 {
 	@MODULE[EngineLightEffect]
 	{
-		%exhaustOffsetZ = 8.5
-		%emissiveOffsetZ = 7.5
+		%exhaustOffsetZ = 9.5
+		%emissiveOffsetZ = 5.6
 	}
 }
 
@@ -509,8 +520,8 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%exhaustOffsetZ = 15.0
-		%emissiveOffsetZ = 12.5
+		%exhaustOffsetZ = 16.0
+		%emissiveOffsetZ = 10.8
 	}
 }
 
@@ -520,8 +531,8 @@
 {
 	@MODULE[EngineLightEffect]
 	{
-		%exhaustOffsetZ = 9.8
-		%emissiveOffsetZ = 8
+		%exhaustOffsetZ = 10.8
+		%emissiveOffsetZ = 7.3
 	}
 }
 // -------------------------------


### PR DESCRIPTION
Hello it's me again ! You know, the noob who doesn't drop it :-p

I'm back again because now we don't get emissive light anymore.
It's because emissive colors check is never on "true" when it's compared to "null", so I propose to you to check if its alpha channel is equal to 0 (value when it's declared).

Also, I've made some solid fuel booster config, stock booster that were forgotten since a while. This could be the opportunity to add them.

Have good day